### PR TITLE
Add helper function to fetch Kaia project IDs from Firestore

### DIFF
--- a/src/app/utils/appSettingsUtils.ts
+++ b/src/app/utils/appSettingsUtils.ts
@@ -91,3 +91,28 @@ export async function updateMarketplaceBanner(message: string | null): Promise<v
     throw new Error("Failed to update marketplace banner.");
   }
 }
+
+/**
+ * Retrieves the list of Kaia project IDs from the appSettings collection in Firestore.
+ *
+ * @returns {Promise<string[]>} - An array of project IDs belonging to Kaia, or an empty array if not found.
+ */
+export async function getKaiaProjects(): Promise<string[]> {
+  try {
+    // Reference to the `kaiaProjects` document in the `appSettings` collection
+    const docRef = doc(db, "appSettings", "kaiaProjects");
+    const docSnapshot = await getDoc(docRef);
+
+    if (docSnapshot.exists()) {
+      const data = docSnapshot.data();
+      // Ensure projectIds is an array of strings or return an empty array if not present
+      return Array.isArray(data.projectIds) ? data.projectIds : [];
+    } else {
+      console.warn("No Kaia projects found in appSettings.");
+      return [];
+    }
+  } catch (error) {
+    console.error("Error fetching Kaia projects:", error);
+    throw new Error("Failed to fetch Kaia projects.");
+  }
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Close #1908 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 