### PR TITLE
Fix: Ensure ipstack API always returns JSON response by appending output=json parameter

### DIFF
--- a/src/app/utils/countryUtils.ts
+++ b/src/app/utils/countryUtils.ts
@@ -21,7 +21,7 @@ interface LocationData {
 export async function fetchLocationData(ip: string): Promise<LocationData> {
   try {
     // Make a request to the ipstack API to fetch location data for the given IP
-    const response = await fetch(`http://api.ipstack.com/${ip}?access_key=${ipstackApiKey}`);
+    const response = await fetch(`https://api.ipstack.com/${ip}?access_key=${ipstackApiKey}&output=json`);
 
     // Use type assertion to tell TypeScript that the response is of type LocationData
     const locationData = await response.json() as LocationData;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Close #1954 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 